### PR TITLE
Catched exception thrown during retrievment of Catched exception thrown ...

### DIFF
--- a/src/main/groovy/com/citytechinc/maven/plugins/osgibundlestatus/checker/FelixBundleStatusChecker.groovy
+++ b/src/main/groovy/com/citytechinc/maven/plugins/osgibundlestatus/checker/FelixBundleStatusChecker.groovy
@@ -85,7 +85,12 @@ class FelixBundleStatusChecker implements BundleStatusChecker {
                 }
             }
 
-            status = getRemoteBundleStatus(bundleSymbolicName, true)
+            try {
+                status = getRemoteBundleStatus(bundleSymbolicName, true)
+            } catch(MojoExecutionException ex) {
+                mojo.log.info "Failed to get remote status, retrying..."
+                mojo.log.debug ex
+            }
 
             Thread.sleep(retryDelay)
 


### PR DESCRIPTION
...during retrievement of the remote bundle status.

This happens when you deploy for example a system fragment that causes the framework to restart. In this case the reset API wont be available and an exception will be thrown. This should cause the plugin to retry, not to fail.
