### PR TITLE
Catched the MojoExecutionException also during initial lookup to prevent...

### DIFF
--- a/src/main/groovy/com/citytechinc/maven/plugins/osgibundlestatus/checker/FelixBundleStatusChecker.groovy
+++ b/src/main/groovy/com/citytechinc/maven/plugins/osgibundlestatus/checker/FelixBundleStatusChecker.groovy
@@ -69,8 +69,8 @@ class FelixBundleStatusChecker implements BundleStatusChecker {
     }
 
     def getStatus(bundleSymbolicName) {
-        def status = getRemoteBundleStatus(bundleSymbolicName, false)
-
+        
+        def status = getRemoteBundleStatusQuiet(bundleSymbolicName, false);
         def retryCount = 0
 
         def requiredStatus = mojo.requiredStatus
@@ -86,13 +86,8 @@ class FelixBundleStatusChecker implements BundleStatusChecker {
                 }
             }
 
-            try {
-                status = getRemoteBundleStatus(bundleSymbolicName, true)
-            } catch(MojoExecutionException ex) {
-                mojo.log.info "Failed to get remote status, retrying..."
-                mojo.log.debug ex
-            }
-
+            status = getRemoteBundleStatusQuiet(bundleSymbolicName, true);
+            
             Thread.sleep(retryDelay)
 
             retryCount++
@@ -101,6 +96,15 @@ class FelixBundleStatusChecker implements BundleStatusChecker {
         status
     }
 
+    def getRemoteBundleStatusQuiet(bundleSymbolicName, force) {
+        try {
+            return getRemoteBundleStatus(bundleSymbolicName, force)
+        } catch(MojoExecutionException ex) {
+            mojo.log.info "Failed to get remote status, retrying..."
+            mojo.log.debug ex
+        }
+    }
+    
     def getRemoteBundleStatus(bundleSymbolicName, force) {
         def status = null
 

--- a/src/test/groovy/com/citytechinc/maven/plugins/osgibundlestatus/checker/FelixBundleStatusCheckerSpec.groovy
+++ b/src/test/groovy/com/citytechinc/maven/plugins/osgibundlestatus/checker/FelixBundleStatusCheckerSpec.groovy
@@ -167,8 +167,8 @@ class FelixBundleStatusCheckerSpec extends Specification {
         checker.checkStatus("other")
 
         then:
-        thrown(MojoExecutionException)
-        verifyRequests(1)
+        thrown(MojoFailureException)
+        verifyRequests(6)
     }
 
     def setupMockServer(json) {


### PR DESCRIPTION
... immediate failure when instance is starting/restarting

I had to adjust the "empty response" test case. Now its conform to the other "failure" test cases. 
